### PR TITLE
#9: Replace QueryEscape with PathEscape

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -57,7 +57,7 @@ func (c *Client) GetApps(limit int, offset int) ([]App, error) {
 
 // GetApp - returns map by ID. https://wit.ai/docs/http/20170307#get__apps__app_id_link
 func (c *Client) GetApp(id string) (*App, error) {
-	resp, err := c.request(http.MethodGet, fmt.Sprintf("/apps/%s", url.QueryEscape(id)), "application/json", nil)
+	resp, err := c.request(http.MethodGet, fmt.Sprintf("/apps/%s", url.PathEscape(id)), "application/json", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *Client) GetApp(id string) (*App, error) {
 
 // DeleteApp - deletes app by ID. https://wit.ai/docs/http/20170307#delete__apps__app_id_link
 func (c *Client) DeleteApp(id string) error {
-	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/apps/%s", url.QueryEscape(id)), "application/json", nil)
+	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/apps/%s", url.PathEscape(id)), "application/json", nil)
 	if err == nil {
 		resp.Close()
 	}
@@ -111,7 +111,7 @@ func (c *Client) UpdateApp(id string, app App) (*App, error) {
 		return nil, err
 	}
 
-	resp, err := c.request(http.MethodPut, fmt.Sprintf("/apps/%s", url.QueryEscape(id)), "application/json", bytes.NewBuffer(appJSON))
+	resp, err := c.request(http.MethodPut, fmt.Sprintf("/apps/%s", url.PathEscape(id)), "application/json", bytes.NewBuffer(appJSON))
 	if err != nil {
 		return nil, err
 	}

--- a/entity.go
+++ b/entity.go
@@ -68,7 +68,7 @@ func (c *Client) CreateEntity(entity Entity) (*Entity, error) {
 
 // GetEntity - returns entity by ID. https://wit.ai/docs/http/20170307#get__entities__entity_id_link
 func (c *Client) GetEntity(id string) (*Entity, error) {
-	resp, err := c.request(http.MethodGet, fmt.Sprintf("/entities/%s", url.QueryEscape(id)), "application/json", nil)
+	resp, err := c.request(http.MethodGet, fmt.Sprintf("/entities/%s", url.PathEscape(id)), "application/json", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) GetEntity(id string) (*Entity, error) {
 
 // DeleteEntity - deletes entity by ID. https://wit.ai/docs/http/20170307#delete__entities__entity_id_link
 func (c *Client) DeleteEntity(id string) error {
-	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s", url.QueryEscape(id)), "application/json", nil)
+	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s", url.PathEscape(id)), "application/json", nil)
 	if err == nil {
 		resp.Close()
 	}
@@ -96,7 +96,7 @@ func (c *Client) DeleteEntity(id string) error {
 
 // DeleteEntityRole - deletes entity role. https://wit.ai/docs/http/20170307#delete__entities__entity_id_role_id_link
 func (c *Client) DeleteEntityRole(entityID string, role string) error {
-	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s:%s", url.QueryEscape(entityID), url.QueryEscape(role)), "application/json", nil)
+	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s:%s", url.PathEscape(entityID), url.PathEscape(role)), "application/json", nil)
 	if err == nil {
 		resp.Close()
 	}
@@ -111,7 +111,7 @@ func (c *Client) UpdateEntity(id string, entity Entity) error {
 		return err
 	}
 
-	resp, err := c.request(http.MethodPut, fmt.Sprintf("/entities/%s", url.QueryEscape(id)), "application/json", bytes.NewBuffer(entityJSON))
+	resp, err := c.request(http.MethodPut, fmt.Sprintf("/entities/%s", url.PathEscape(id)), "application/json", bytes.NewBuffer(entityJSON))
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (c *Client) AddEntityValue(entityID string, value EntityValue) (*Entity, er
 		return nil, err
 	}
 
-	resp, err := c.request(http.MethodPost, fmt.Sprintf("/entities/%s/values", url.QueryEscape(entityID)), "application/json", bytes.NewBuffer(valueJSON))
+	resp, err := c.request(http.MethodPost, fmt.Sprintf("/entities/%s/values", url.PathEscape(entityID)), "application/json", bytes.NewBuffer(valueJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (c *Client) AddEntityValue(entityID string, value EntityValue) (*Entity, er
 
 // DeleteEntityValue - Delete a canonical value from the entity. https://wit.ai/docs/http/20170307#delete__entities__entity_id_values_link
 func (c *Client) DeleteEntityValue(entityID string, value string) error {
-	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s/values/%s", url.QueryEscape(entityID), url.QueryEscape(value)), "application/json", nil)
+	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s/values/%s", url.PathEscape(entityID), url.PathEscape(value)), "application/json", nil)
 	if err == nil {
 		resp.Close()
 	}
@@ -168,7 +168,7 @@ func (c *Client) AddEntityValueExpression(entityID string, value string, express
 		return nil, err
 	}
 
-	resp, err := c.request(http.MethodPost, fmt.Sprintf("/entities/%s/values/%s/expressions", url.QueryEscape(entityID), url.QueryEscape(value)), "application/json", bytes.NewBuffer(exprJSON))
+	resp, err := c.request(http.MethodPost, fmt.Sprintf("/entities/%s/values/%s/expressions", url.PathEscape(entityID), url.PathEscape(value)), "application/json", bytes.NewBuffer(exprJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (c *Client) AddEntityValueExpression(entityID string, value string, express
 
 // DeleteEntityValueExpression - Delete an expression of the canonical value of the entity. https://wit.ai/docs/http/20170307#delete__entities__entity_id_values__value_id_expressions_link
 func (c *Client) DeleteEntityValueExpression(entityID string, value string, expression string) error {
-	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s/values/%s/expressions/%s", url.QueryEscape(entityID), url.QueryEscape(value), url.QueryEscape(expression)), "application/json", nil)
+	resp, err := c.request(http.MethodDelete, fmt.Sprintf("/entities/%s/values/%s/expressions/%s", url.PathEscape(entityID), url.PathEscape(value), url.PathEscape(expression)), "application/json", nil)
 	if err == nil {
 		resp.Close()
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -129,24 +129,24 @@ func TestIntegrationEntities(t *testing.T) {
 	}
 	// add entity value 2
 	if _, err = c.AddEntityValue(integrationEntity.ID, EntityValue{
-		Value:       "HCMC",
-		Expressions: []string{"HCMC"},
+		Value:       "Ho Chi Minh City",
+		Expressions: []string{"Ho Chi Minh City"},
 	}); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 	// add entity value expression
-	if _, err = c.AddEntityValueExpression(integrationEntity.ID, "HCMC", "HoChiMinh"); err != nil {
+	if _, err = c.AddEntityValueExpression(integrationEntity.ID, "Ho Chi Minh City", "HoChiMinh"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if _, err = c.AddEntityValueExpression(integrationEntity.ID, "HCMC", "hochiminhcity"); err != nil {
+	if _, err = c.AddEntityValueExpression(integrationEntity.ID, "Ho Chi Minh City", "hochiminhcity"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if err = c.DeleteEntityValueExpression(integrationEntity.ID, "HCMC", "HoChiMinh"); err != nil {
+	if err = c.DeleteEntityValueExpression(integrationEntity.ID, "Ho Chi Minh City", "HoChiMinh"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 
 	// delete entity value 1
-	if err = c.DeleteEntityValue(integrationEntity.ID, "HCMC"); err != nil {
+	if err = c.DeleteEntityValue(integrationEntity.ID, "Ho Chi Minh City"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 

--- a/message.go
+++ b/message.go
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
-
 package witai
 
 import (
@@ -100,7 +99,7 @@ func (c *Client) Speech(req *MessageRequest) (*MessageResponse, error) {
 }
 
 func buildParseQuery(req *MessageRequest) string {
-	q := fmt.Sprintf("?q=%s", url.QueryEscape(req.Query))
+	q := fmt.Sprintf("?q=%s", url.PathEscape(req.Query))
 	if len(req.MsgID) != 0 {
 		q += fmt.Sprintf("&msg_id=%s", req.MsgID)
 	}


### PR DESCRIPTION
Example value: `Ho Chi Minh City`.
Previous code would escape as `Ho+Chi+Minh+City` and requests will fail.
The new code will escape as `Ho%20Chi%20Minh%20City` and will work.